### PR TITLE
Handle multiple pages of function results

### DIFF
--- a/push/loggly/client.rb
+++ b/push/loggly/client.rb
@@ -28,13 +28,13 @@ module Push
 
       def push_single!(messages)
         messages.map do |message|
-          body = message.gsub(/\R+/, '')
+          body = message.delete("\n")
           request!(body)
         end
       end
 
       def push_bulk!(messages)
-        body = messages.map { |message| message.gsub(/\R+/, '') }.join("\n")
+        body = messages.map { |message| message.delete("\n") }.join("\n")
         request!(body)
       end
 

--- a/push/loggly/client.rb
+++ b/push/loggly/client.rb
@@ -28,12 +28,13 @@ module Push
 
       def push_single!(messages)
         messages.map do |message|
-          request!(message)
+          body = message.gsub(/\R+/, '')
+          request!(body)
         end
       end
 
       def push_bulk!(messages)
-        body = messages.map(&:chomp).join("\n")
+        body = messages.map { |message| message.gsub(/\R+/, '') }.join("\n")
         request!(body)
       end
 

--- a/spec/push/loggly/client_spec.rb
+++ b/spec/push/loggly/client_spec.rb
@@ -11,7 +11,7 @@ describe Push::Loggly::Client do
     let(:messages) do
       [
         "Message one\n",
-        "Message two\n"
+        "Message two\t{ json: \n { key: 'value',\n many: 'lines' } }\n"
       ]
     end
 

--- a/spec/support/helpers/requests.rb
+++ b/spec/support/helpers/requests.rb
@@ -8,7 +8,7 @@ module Helpers
 
     def stub_loggly_push(opts = {})
       message = opts.fetch(:message)
-      request_body = message.gsub(/\R+/, '')
+      request_body = message.delete("\n")
       stub_loggly_push_initial
         .with(
           headers: {
@@ -25,7 +25,7 @@ module Helpers
 
     def stub_loggly_push_bulk(opts = {})
       messages = opts.fetch(:messages)
-      request_body = messages.map { |message| message.gsub(/\R+/, '') }.join("\n")
+      request_body = messages.map { |message| message.delete("\n") }.join("\n")
       stub_request(:post, loggly_url_for('bulk/1234/'))
         .with(
           headers: { 'CONTENT-TYPE' => 'text/plain' },

--- a/spec/support/helpers/requests.rb
+++ b/spec/support/helpers/requests.rb
@@ -7,13 +7,15 @@ module Helpers
     end
 
     def stub_loggly_push(opts = {})
+      message = opts.fetch(:message)
+      request_body = message.gsub(/\R+/, '')
       stub_loggly_push_initial
         .with(
           headers: {
             'X-LOGGLY-TAG' => opts.fetch(:tags),
             'CONTENT-TYPE' => 'text/plain'
           },
-          body: opts.fetch(:message)
+          body: request_body
         )
         .to_return(
           status: opts.fetch(:status) { 200 },
@@ -23,7 +25,7 @@ module Helpers
 
     def stub_loggly_push_bulk(opts = {})
       messages = opts.fetch(:messages)
-      request_body = messages.map(&:chomp).join("\n")
+      request_body = messages.map { |message| message.gsub(/\R+/, '') }.join("\n")
       stub_request(:post, loggly_url_for('bulk/1234/'))
         .with(
           headers: { 'CONTENT-TYPE' => 'text/plain' },

--- a/subscribe/lambda/function.rb
+++ b/subscribe/lambda/function.rb
@@ -43,10 +43,10 @@ module Subscribe
           loop do
             response = lambda.list_functions(marker: marker)
             functions << response.functions
-            break unless marker = response.next_marker
+            break unless (marker = response.next_marker)
           end
 
-          return functions.flatten
+          functions.flatten
         end
       end
 

--- a/subscribe/lambda/function.rb
+++ b/subscribe/lambda/function.rb
@@ -37,16 +37,7 @@ module Subscribe
         private
 
         def all_functions(lambda)
-          marker = nil
-          functions = []
-
-          loop do
-            response = lambda.list_functions(marker: marker)
-            functions << response.functions
-            break unless (marker = response.next_marker)
-          end
-
-          functions.flatten
+          lambda.list_functions.flat_map(&:functions)
         end
       end
 

--- a/template.yml
+++ b/template.yml
@@ -19,7 +19,7 @@ Metadata:
       - forwarder
       - lambda
     HomePageUrl: https://github.com/amaabca/cloudwatch_loggly
-    SemanticVersion: 0.1.0
+    SemanticVersion: 0.2.0
     SourceCodeUrl: https://github.com/amaabca/cloudwatch_loggly
 
 Parameters:


### PR DESCRIPTION
- The #list_functions method returns 50 items max. If there are more items, the response includes a next_marker field, which needs to be passed in with a subsequent call to get the next page. This value is nil when there are no more items.
- In the .all method, this now loops through #list_functions calls until next_marker comes back nil, merging the returned functions into an array used to return a list of Function instances.
- I also dropped the #stale? method since it was only used to negate the #up_to_date? method, adding cognitive complexity.
- See https://docs.aws.amazon.com/sdkforruby/api/Aws/Lambda/Client.html#list_functions-instance_method for reference.
- This also addresses an issue where the log message includes `\n`, which Loggly interprets as a separate log entry. All newlines now get stripped out, so they don't show up like this:

![image](https://user-images.githubusercontent.com/473578/59132181-ad92e980-8931-11e9-8400-c0edb6ef9ec9.png)

Test event submitted with `Push::Loggly::Client.new(...).push!(messages)`:

![image](https://user-images.githubusercontent.com/473578/59132452-75d87180-8932-11e9-996b-1faf0d22bf38.png)

