### PR TITLE
Version 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ## CloudWatch to Loggly Forwarder
 
+[![Version](https://img.shields.io/github/tag/amaabca/cloudwatch_loggly.svg)](https://img.shields.io/github/tag/amaabca/cloudwatch_loggly.svg)
+[![Build Status](https://travis-ci.com/amaabca/cloudwatch_loggly.svg?branch=master)](https://travis-ci.com/amaabca/cloudwatch_loggly.svg?branch=master)
+
 Cloudwatch::Loggly is an AWS [SAM](https://github.com/awslabs/serverless-application-model) application that automatically ships the logs from Lambda functions to [Loggly](https://www.loggly.com).
 
 ### Overview
@@ -53,6 +56,8 @@ By default, the value from the `FilterPatternParameter` is used when subscribing
 2. Ensure Docker is installed (the `--use-container` flag is specified during the build phase).
 3. Update the `SemanticVersion` value in `template.yml`.
 4. run `AWS_PROFILE=myprofilename make`
+
+**NOTE**: After publishing a new version, it can take AWS a few hours to propagate the changes across regions. You'll likely see the version update on the Serverless Application Repository in `us-east-1` first.
 
 ### Licence
 

--- a/spec/support/helpers/environment.rb
+++ b/spec/support/helpers/environment.rb
@@ -7,7 +7,9 @@ module Helpers
       ENV['LOG_TAGS'] = opts.fetch(:log_tags) { 'test,spec' }
       ENV['BULK_TRANSMISSION'] = opts.fetch(:bulk) { 'true' }
       ENV['FILTER_PATTERN'] = opts.fetch(:filter_pattern) { '' }
-      ENV['DESTINATION_ARN'] = opts.fetch(:destination_arn) { 'arn' }
+      ENV['DESTINATION_ARN'] = opts.fetch(:destination_arn) do
+        'arn:aws:lambda:us-west-2:123456789012:function:func'
+      end
       ENV['LOG_OUTPUT'] = opts.fetch(:log_output) { 'false' }
     end
   end

--- a/template.yml
+++ b/template.yml
@@ -19,7 +19,7 @@ Metadata:
       - forwarder
       - lambda
     HomePageUrl: https://github.com/amaabca/cloudwatch_loggly
-    SemanticVersion: 0.2.0
+    SemanticVersion: 0.3.0
     SourceCodeUrl: https://github.com/amaabca/cloudwatch_loggly
 
 Parameters:


### PR DESCRIPTION
- Add an additional check on the `destination_arn` of the
  subscription filter against the current lambda arn when
  subscribing functions.
- This allows a seamless "upgrade" of subscription filters if
  the SAM application has been deleted and replaced (i.e. when
  upgrading a version).
- If the destination_arn changes for any reason, the subscription
  filter matching the name `ShipToLoggly` will be replaced with
  an up to date subscription.
- Add badges to track build status and the latest version on
  the README.
- Update the `SemanticVersion` to release version `0.3.0`.
- Update the README with a note about deployment propagation.