### PR TITLE
Version 0.5.0 | CloudWatchLogs API Rate Limits

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -19,7 +19,7 @@ Metadata:
       - forwarder
       - lambda
     HomePageUrl: https://github.com/amaabca/cloudwatch_loggly
-    SemanticVersion: 0.4.0
+    SemanticVersion: 0.5.0
     SourceCodeUrl: https://github.com/amaabca/cloudwatch_loggly
 
 Parameters:


### PR DESCRIPTION
- Additional rate limits are being hit on the call to CloudWatchLogs describe_subscription_filters.
- Initialize the Aws::CloudWatchLogs::Client with retry options set, the same as was done for the Aws::Lambda::Client.
- 3 retries will occur with delays of 1s, 2s, then 2s again before failing.
- Add test in subscribe_all to ensure the retries are happening, by checking the total time is >= 5s.

See https://github.com/amaabca/cloudwatch_loggly/pull/6 for previous fix for the Lambda client.

Error currently hit:
```
{
  "errorMessage": "Rate exceeded",
  "errorType": "Function<Aws::CloudWatchLogs::Errors::ThrottlingException>",
  "stackTrace": [
    "/var/runtime/gems/aws-sdk-core-3.47.0/lib/seahorse/client/plugins/raise_response_errors.rb:15:in `call'",
    "/var/runtime/gems/aws-sdk-core-3.47.0/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:20:in `call'",
    "/var/runtime/gems/aws-sdk-core-3.47.0/lib/aws-sdk-core/plugins/idempotency_token.rb:17:in `call'",
    "/var/runtime/gems/aws-sdk-core-3.47.0/lib/aws-sdk-core/plugins/param_converter.rb:24:in `call'",
    "/var/runtime/gems/aws-sdk-core-3.47.0/lib/aws-sdk-core/plugins/response_paging.rb:10:in `call'",
    "/var/runtime/gems/aws-sdk-core-3.47.0/lib/seahorse/client/plugins/response_target.rb:23:in `call'",
    "/var/runtime/gems/aws-sdk-core-3.47.0/lib/seahorse/client/request.rb:70:in `send_request'",
    "/var/runtime/gems/aws-sdk-cloudwatchlogs-1.15.0/lib/aws-sdk-cloudwatchlogs/client.rb:1079:in `describe_subscription_filters'",
    "/var/task/lambda/function.rb:116:in `subscriptions'",
    "/var/task/lambda/function.rb:125:in `remote_filter_pattern'",
    "/var/task/lambda/function.rb:88:in `up_to_date?'",
    "/var/task/lambda/function.rb:73:in `skip?'",
    "/var/task/lambda/function.rb:30:in `block in subscribe_all!'",
    "/var/task/lambda/function.rb:29:in `each'",
    "/var/task/lambda/function.rb:29:in `each_with_object'",
    "/var/task/lambda/function.rb:29:in `subscribe_all!'",
    "/var/task/handler.rb:13:in `handle'"
  ]
}
```

This change was also successfully tested by manually updating the deployed lambda.