### PR TITLE
87139 - Capture Additional Tags to be sent to Loggly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7'
+          ruby-version: "2.7"
       - name: Build and test with Rake
         run: |
           gem install bundler

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,12 +4,12 @@ AllCops:
   Exclude:
     - 'bin/**/*'
     - 'vendor/**/*'
-Documentation:
+Style/Documentation:
   Enabled: false
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 Style/Lambda:
   EnforcedStyle: literal

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ If you wish to opt-out a Lambda function from Loggly delivery, add the `cloudwat
 
 By default, the value from the `FilterPatternParameter` is used when subscribing to CloudWatch log events. This value can be overridden on a per-function basis by setting the Lambda function's `cloudwatch_loggly_filter_pattern` tag to the value that you prefer.
 
+### Adding tags to cloudwatch for a lambda
+
+By default, the only tags that will be sent to loggly are the ones specified in `LogTagsParameter`, the owner (account number) and the log group that the logs are from. If you would like to send additional tags then you must add a tag to the lambda that starts with `cloudwatch_loggly_tag`. For example a log group with the tag `cloudwatch_loggly_mfe: omninotes` will have the tag `omninotes` added to the loggly tags.
+
 ### Deploying to the AWS Serverless Application Repository
 
 1. Ensure you have the `aws` and `sam` CLI tools installed locally.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-## CloudWatch to Loggly Forwarder
+# CloudWatch to Loggly Forwarder
 
 [![Version](https://img.shields.io/github/tag/amaabca/cloudwatch_loggly.svg)](https://img.shields.io/github/tag/amaabca/cloudwatch_loggly.svg)
 [![Build Status](https://travis-ci.com/amaabca/cloudwatch_loggly.svg?branch=master)](https://travis-ci.com/amaabca/cloudwatch_loggly.svg?branch=master)
 
 Cloudwatch::Loggly is an AWS [SAM](https://github.com/awslabs/serverless-application-model) application that automatically ships the logs from Lambda functions to [Loggly](https://www.loggly.com).
 
-### Overview
+## Overview
 
 The SAM template contains two key Lambda functions:
 
-#### Push Function
+### Push Function
 
 This function is responsible for sending events to Loggly.
 
@@ -17,7 +17,7 @@ This function is designed to be triggered by Cloudwatch Log [events](https://doc
 
 The Push function reads Cloudwatch Log data via the incoming event, decompresses it and sends the data via Loggly's [HTTP API](https://www.loggly.com/docs/api-sending-data/).
 
-#### Subscribe Function
+### Subscribe Function
 
 This function periodically wakes up and lists all Lambda functions in its current region.
 
@@ -25,7 +25,7 @@ For each function in the region, a [subscription filter](https://docs.aws.amazon
 
 The interval that this function executes is configurable via the `ScheduleExpressionParameter` template parameter. Please see the AWS [schedule expression documentation](https://docs.aws.amazon.com/lambda/latest/dg/tutorial-scheduled-events-schedule-expressions.html) for allowed values.
 
-### Configuration
+## Configuration
 
 The SAM template accepts the following parameters:
 
@@ -36,25 +36,25 @@ The SAM template accepts the following parameters:
 - **ScheduleExpressionParameter** [optional]: The AWS schedule expression for the Subscribe function trigger. By default, this executes daily at 16:00 UTC.
 - **FunctionTimeoutParameter** [optional]: The Lambda timeout value in seconds for both the Push and Subscribe function. This value defaults to '10'.
 
-### Parameter Overrides
+## Parameter Overrides
 
 Lambda functions may be tagged with "special" values to override default behaviour.
 
-#### `cloudwatch_loggly_suppress_subscribe`
+### `cloudwatch_loggly_suppress_subscribe`
 
 This application assumes an "opt-out" approach when shipping logs. By default, the log groups for all Lambda functions in a region are subscribed to deliver data to Loggly.
 
 If you wish to opt-out a Lambda function from Loggly delivery, add the `cloudwatch_loggly_suppress_subscribe` tag to the function with any non-blank value.
 
-#### `cloudwatch_loggly_filter_pattern`
+### `cloudwatch_loggly_filter_pattern`
 
 By default, the value from the `FilterPatternParameter` is used when subscribing to CloudWatch log events. This value can be overridden on a per-function basis by setting the Lambda function's `cloudwatch_loggly_filter_pattern` tag to the value that you prefer.
 
-### Adding tags to cloudwatch for a lambda
+## Adding tags to cloudwatch for a lambda
 
-By default, the only tags that will be sent to loggly are the ones specified in `LogTagsParameter`, the owner (account number) and the log group that the logs are from. If you would like to send additional tags then you must add a tag to the lambda that starts with `cloudwatch_loggly_tag`. For example a log group with the tag `cloudwatch_loggly_mfe: omninotes` will have the tag `omninotes` added to the loggly tags.
+By default, the only tags that will be sent to loggly are the ones specified in `LogTagsParameter`, the owner (account number) and the log group that the logs are from. If you would like to send additional tags then you must add a tag to the lambda that includes `cloudwatch_loggly_tag`. For example a lambda with the tag `cloudwatch_loggly_tag_mfe: omninotes` will have the tag `omninotes` added to the log in loggly.
 
-### Deploying to the AWS Serverless Application Repository
+## Deploying to the AWS Serverless Application Repository
 
 1. Ensure you have the `aws` and `sam` CLI tools installed locally.
 2. Ensure Docker is installed (the `--use-container` flag is specified during the build phase).
@@ -63,6 +63,6 @@ By default, the only tags that will be sent to loggly are the ones specified in 
 
 **NOTE**: After publishing a new version, it can take AWS a few hours to propagate the changes across regions. You'll likely see the version update on the Serverless Application Repository in `us-east-1` first.
 
-### Licence
+## Licence
 
 Cloudwatch::Loggly is licensed under the MIT License. Please see LICENSE for details.

--- a/push/handler.rb
+++ b/push/handler.rb
@@ -6,6 +6,7 @@ require 'stringio'
 require 'json'
 require 'uri'
 require 'net/http'
+require 'aws-sdk-lambda'
 
 require_relative 'loggly/exceptions/base'
 require_relative 'loggly/exceptions/client_error'

--- a/spec/push/cloudwatch/event_spec.rb
+++ b/spec/push/cloudwatch/event_spec.rb
@@ -5,15 +5,37 @@ describe Push::Cloudwatch::Event do
   let(:message) { read_fixture('push/decoded.json') }
   subject { described_class.new(raw: event) }
 
+  before(:each) do
+    ENV['REGION'] = 'test'
+  end
+
+  after(:each) do
+    ENV['REGION'] = ''
+  end
+
   describe '#to_loggly!' do
     before(:each) do
       prepare_environment!
       stub_loggly_push_bulk(messages: [message])
     end
 
-    it 'returns the response' do
-      value = subject.to_loggly!
-      expect(value).to eq('{"success":true}')
+    it 'raises a webmock exception' do
+      expect { subject.to_loggly! }.to raise_exception(WebMock::NetConnectNotAllowedError)
+    end
+
+    context 'when using stubbs' do
+      before(:each) do
+        allow(subject).to receive(:retry_opts).and_return(
+          stub_responses: {
+            list_tags: { 'tags': { 'cloudwatch_loggly_tag_app_name' => 'TEST_APP_NAME' } }
+          }
+        )
+      end
+
+      it 'returns the response' do
+        value = subject.to_loggly!
+        expect(value).to eq('{"success":true}')
+      end
     end
   end
 end

--- a/spec/push/handler_spec.rb
+++ b/spec/push/handler_spec.rb
@@ -6,8 +6,16 @@ describe Push do
     let(:message) { read_fixture('push/decoded.json') }
 
     before(:each) do
+      ENV['REGION'] = 'test'
+      allow_any_instance_of(Push::Cloudwatch::Event).to receive(:get_lambda_tags).and_return(
+        'cloudwatch_loggly_tag_app_name' => 'TEST_APP_NAME'
+      )
       prepare_environment!
       stub_loggly_push_bulk(messages: [message])
+    end
+
+    after(:each) do
+      ENV['REGION'] = ''
     end
 
     it 'returns the response body' do

--- a/template.yml
+++ b/template.yml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: >
   CloudWatch to Loggly Log Forwarder
@@ -39,16 +39,16 @@ Parameters:
     Description: >
       An AWS CloudWatch subscription filter pattern directive. Defaults to the empty string.
       See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
-    Default: ''
+    Default: ""
   BulkTransmissionParameter:
     Type: String
     Description: >
       Tells the log forwarder to use Loggly's bulk transmission endpoint for increased efficiency. Defaults to true.
       See: https://www.loggly.com/docs/http-bulk-endpoint/
-    Default: 'true'
+    Default: "true"
     AllowedValues:
-      - 'true'
-      - 'false'
+      - "true"
+      - "false"
   ScheduleExpressionParameter:
     Type: String
     Description: >
@@ -72,8 +72,17 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess
+      Policies:
+        - PolicyName: ListLambdaTags
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:ListTags
+                Resource: "*"
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           Action:
             - sts:AssumeRole
@@ -90,7 +99,7 @@ Resources:
       Policies:
         - PolicyName: LogSubscriptionFilterWriteAccess
           PolicyDocument:
-            Version: '2012-10-17'
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action:
@@ -98,9 +107,9 @@ Resources:
                   - lambda:ListTags
                   - logs:DescribeSubscriptionFilters
                   - logs:PutSubscriptionFilter
-                Resource: '*'
+                Resource: "*"
       AssumeRolePolicyDocument:
-        Version: '2012-10-17'
+        Version: "2012-10-17"
         Statement:
           Action:
             - sts:AssumeRole
@@ -120,6 +129,7 @@ Resources:
           LOGGLY_TOKEN: !Ref LogglyTokenParameter
           LOG_TAGS: !Ref LogTagsParameter
           BULK_TRANSMISSION: !Ref BulkTransmissionParameter
+          REGION: !Ref AWS::Region
       Tags:
         cloudwatch_loggly_suppress_subscribe: true
   CloudwatchLogglySubscribeFunction:


### PR DESCRIPTION
[AB#87139](https://dev.azure.com/AMA-Ent/ccb94584-03a5-426b-9211-75a5115f75dc/_workitems/edit/87139)

### Changes

- Added a method that will check the tags for a lambda and if any start with cloudwatch_loggly_tag it will get added as a tag when the logs are sent to loggly
- Updated tests, Readme and Rubocop.yml file

### Test
- This is deployed in the staging account for membership
- Add a tag that starts with cloudwatch_loggly_tag to any lambda there and trigger the lambda
- Go to loggly and search for the tag

- [x] I have written a detailed PR message and detailed commits explaining what is being changed and why