### PR TITLE
87819: Handle throttling exceptions

### DIFF
--- a/push/cloudwatch/event.rb
+++ b/push/cloudwatch/event.rb
@@ -20,13 +20,18 @@ module Push
       private
 
       def retry_opts
-        { max_attempts: 4, retry_mode: 'standard' }
+        { max_attempts: 2, retry_mode: 'standard' }
       end
 
       def get_lambda_tags(opts = {})
+        retries ||= 0
+        puts "try ##{ retries }"
         Aws::Lambda::Client.new(retry_opts.merge(opts)).list_tags(
           resource: 'arn:aws:lambda:' + ENV.fetch('REGION') + ':' + owner + ':function:' + log_group
         ).tags
+      rescue Aws::Lambda::Errors::ThrottlingException => e
+        puts e.inspect
+        retry if (retries += 1) < 3
       end
 
       def data

--- a/push/cloudwatch/event.rb
+++ b/push/cloudwatch/event.rb
@@ -34,7 +34,9 @@ module Push
         puts "ThrottlingExceptionGetLambdaTags (retry attempt: #{retries}): #{e.inspect}"
         retry if (retries += 1) < 3
 
-        raise StandardError, 'ThrottlingExceptionRetryLimitExceeded'
+        puts 'ThrottlingExceptionGetLambdaTagsRetryLimitExceeded'
+
+        []
       end
       # rubocop:enable Metrics/AbcSize
 

--- a/push/cloudwatch/event.rb
+++ b/push/cloudwatch/event.rb
@@ -30,8 +30,8 @@ module Push
         Aws::Lambda::Client.new(retry_opts.merge(opts)).list_tags(
           resource: 'arn:aws:lambda:' + ENV.fetch('REGION') + ':' + owner + ':function:' + log_group
         ).tags
-      rescue Aws::Lambda::Errors::ThrottlingException => e
-        puts "ThrottlingExceptionGetLambdaTags (retry attempt: #{retries}): #{e.inspect}"
+      rescue Aws::Lambda::Errors::ThrottlingException
+        puts "ThrottlingExceptionGetLambdaTags - Retry attempt: #{retries}"
         retry if (retries += 1) < 3
 
         puts 'ThrottlingExceptionGetLambdaTagsRetryLimitExceeded'

--- a/push/cloudwatch/event.rb
+++ b/push/cloudwatch/event.rb
@@ -20,17 +20,16 @@ module Push
       private
 
       def retry_opts
-        { max_attempts: 2, retry_mode: 'standard' }
+        { max_attempts: 4, retry_mode: 'standard' }
       end
 
       def get_lambda_tags(opts = {})
         retries ||= 0
-        puts "try ##{ retries }"
         Aws::Lambda::Client.new(retry_opts.merge(opts)).list_tags(
           resource: 'arn:aws:lambda:' + ENV.fetch('REGION') + ':' + owner + ':function:' + log_group
         ).tags
       rescue Aws::Lambda::Errors::ThrottlingException => e
-        puts e.inspect
+        puts "ThrottlingExceptionGetLambdaTags (retry attempt: #{ retries }): #{ e.inspect }"
         retry if (retries += 1) < 3
       end
 

--- a/spec/push/cloudwatch/event_spec.rb
+++ b/spec/push/cloudwatch/event_spec.rb
@@ -36,6 +36,21 @@ describe Push::Cloudwatch::Event do
         value = subject.to_loggly!
         expect(value).to eq('{"success":true}')
       end
+
+      context 'when throttling exception is thrown' do
+        before(:each) do
+          allow(Aws::Lambda::Client).to receive(:new).and_raise(
+            Aws::Lambda::Errors::ThrottlingException.new('test', 'test')
+          )
+        end
+
+        it 'raises exception when retry limit exceeded' do
+          expect { subject.to_loggly! }.to raise_error(
+            StandardError,
+            'ThrottlingExceptionRetryLimitExceeded'
+          )
+        end
+      end
     end
   end
 end

--- a/spec/push/cloudwatch/event_spec.rb
+++ b/spec/push/cloudwatch/event_spec.rb
@@ -44,7 +44,7 @@ describe Push::Cloudwatch::Event do
           )
         end
 
-        it 'raises exception when retry limit exceeded' do
+        it 'retries method 3 times' do
           subject.to_loggly!
           expect(Aws::Lambda::Client).to have_received(:new).exactly(3).times
         end

--- a/spec/push/cloudwatch/event_spec.rb
+++ b/spec/push/cloudwatch/event_spec.rb
@@ -45,10 +45,8 @@ describe Push::Cloudwatch::Event do
         end
 
         it 'raises exception when retry limit exceeded' do
-          expect { subject.to_loggly! }.to raise_error(
-            StandardError,
-            'ThrottlingExceptionRetryLimitExceeded'
-          )
+          subject.to_loggly!
+          expect(Aws::Lambda::Client).to have_received(:new).exactly(3).times
         end
       end
     end

--- a/spec/subscribe/lambda/function_spec.rb
+++ b/spec/subscribe/lambda/function_spec.rb
@@ -52,19 +52,14 @@ describe Subscribe::Lambda::Function do
       end
 
       it 'raises exception when retry limit exceeded' do
-        expected = expect do
-          described_class.new(
-            arn: 'test',
-            name: 'test',
-            cloudwatch: cloudwatch,
-            lambda: lambda
-          )
-        end
-
-        expected.to raise_error(
-          StandardError,
-          'ThrottlingExceptionRetryLimitExceeded'
+        described_class.new(
+          arn: 'test',
+          name: 'test',
+          cloudwatch: cloudwatch,
+          lambda: lambda
         )
+
+        expect(lambda).to have_received(:list_tags).exactly(3).times
       end
     end
   end
@@ -266,10 +261,8 @@ describe Subscribe::Lambda::Function do
         end
 
         it 'raises exception when retry limit exceeded' do
-          expect { described_class.subscribe_all!(lambda, cloudwatch) }.to raise_error(
-            StandardError,
-            'ThrottlingExceptionRetryLimitExceeded'
-          )
+          described_class.subscribe_all!(lambda, cloudwatch)
+          expect(cloudwatch).to have_received(:describe_subscription_filters).exactly(6).times
         end
       end
     end

--- a/spec/subscribe/lambda/function_spec.rb
+++ b/spec/subscribe/lambda/function_spec.rb
@@ -51,7 +51,7 @@ describe Subscribe::Lambda::Function do
         )
       end
 
-      it 'raises exception when retry limit exceeded' do
+      it 'retries method 3 times for each function' do
         described_class.new(
           arn: 'test',
           name: 'test',
@@ -260,7 +260,7 @@ describe Subscribe::Lambda::Function do
           )
         end
 
-        it 'raises exception when retry limit exceeded' do
+        it 'retries method 3 times for each function' do
           described_class.subscribe_all!(lambda, cloudwatch)
           expect(cloudwatch).to have_received(:describe_subscription_filters).exactly(6).times
         end

--- a/subscribe/lambda/function.rb
+++ b/subscribe/lambda/function.rb
@@ -106,7 +106,9 @@ module Subscribe
         puts "ThrottlingExceptionFetchTags (retry attempt: #{retries}): #{e.inspect}"
         retry if (retries += 1) < 3
 
-        raise StandardError, 'ThrottlingExceptionRetryLimitExceeded'
+        puts 'ThrottlingExceptionFetchTagsRetryLimitExceeded'
+
+        []
       end
 
       def cloudwatch_log_group_name
@@ -127,7 +129,8 @@ module Subscribe
         puts "ThrottlingExceptionSubscriptions (retry attempt: #{retries}): #{e.inspect}"
         retry if (retries += 1) < 3
 
-        raise StandardError, 'ThrottlingExceptionRetryLimitExceeded'
+        puts 'ThrottlingExceptionSubscriptionsRetryLimitExceeded'
+        []
       end
 
       def remote_filter_pattern

--- a/subscribe/lambda/function.rb
+++ b/subscribe/lambda/function.rb
@@ -99,10 +99,9 @@ module Subscribe
 
       def fetch_tags!
         retries ||= 0
-        puts "Retry list tags ##{ retries }"
         lambda.list_tags(resource: arn).tags
       rescue Aws::Lambda::Errors::ThrottlingException => e
-        puts e.inspect
+        puts "ThrottlingExceptionFetchTags (retry attempt: #{ retries }): #{ e.inspect }"
         retry if (retries += 1) < 3
       end
 
@@ -118,7 +117,8 @@ module Subscribe
             filter_name_prefix: FILTER_NAME,
             limit: 1
           ).subscription_filters
-        rescue Aws::CloudWatchLogs::Errors::ThrottlingException
+        rescue Aws::CloudWatchLogs::Errors::ThrottlingException => e
+          puts "ThrottlingExceptionSubscriptions (retry attempt: #{ retries }): #{ e.inspect }"
           retry if (retries += 1) < 3
         end
       end

--- a/subscribe/lambda/function.rb
+++ b/subscribe/lambda/function.rb
@@ -102,11 +102,11 @@ module Subscribe
       def fetch_tags!
         retries ||= 0
         lambda.list_tags(resource: arn).tags
-      rescue Aws::Lambda::Errors::ThrottlingException => e
-        puts "ThrottlingExceptionFetchTags (retry attempt: #{retries}): #{e.inspect}"
+      rescue Aws::Lambda::Errors::ThrottlingException
+        puts "ThrottlingExceptionFetchTags (Resource: #{name}) - Retry attempt: #{retries}"
         retry if (retries += 1) < 3
 
-        puts 'ThrottlingExceptionFetchTagsRetryLimitExceeded'
+        puts "ThrottlingExceptionFetchTagsRetryLimitExceeded (Resource: #{name})"
 
         []
       end
@@ -125,11 +125,11 @@ module Subscribe
             limit: 1
           ).subscription_filters
         end
-      rescue Aws::CloudWatchLogs::Errors::ThrottlingException => e
-        puts "ThrottlingExceptionSubscriptions (retry attempt: #{retries}): #{e.inspect}"
+      rescue Aws::CloudWatchLogs::Errors::ThrottlingException
+        puts "ThrottlingExceptionSubscriptions (Resource: #{name}) - Retry attempt: #{retries}"
         retry if (retries += 1) < 3
 
-        puts 'ThrottlingExceptionSubscriptionsRetryLimitExceeded'
+        puts "ThrottlingExceptionSubscriptionsRetryLimitExceeded (Resource: #{name})"
         []
       end
 


### PR DESCRIPTION
Adjust the retry logic to handle the exceptions so we can better see how this is failing (potentially if the failures continue).

ADO: https://dev.azure.com/AMA-Ent/AMA-Ent/_workitems/edit/87819